### PR TITLE
Set the `omit-default-module-path=false` wasm-bindgen option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ qcms = "0.3"
 [profile.release]
 lto = true
 opt-level = 3
+
+[package.metadata.wasm-pack.profile.release.wasm-bindgen]
+omit-default-module-path = true


### PR DESCRIPTION
This is the diff in the generated code:
```diff
--- ./my_output_dir2/qcms.js    2025-05-13 16:15:28.664573459 +0200
+++ ./my_output_dir/qcms.js     2025-05-13 16:13:45.219869438 +0200
@@ -235,9 +235,7 @@
         }
     }
 
-    if (typeof module_or_path === 'undefined') {
-        module_or_path = new URL('qcms_bg.wasm', import.meta.url);
-    }
+
     const imports = __wbg_get_imports();
 
     if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
```

I would ideally like to remove the whole `__wbg_init` exported function (and `__wbg_load`, used by it), since pdf.js does not need it and thus it's just dead code, but there isn't an easy way to do it with `wasm-pack`/`wasm-bindgen`.

This PR mostly solves the annoyance of having to add the comment for bundlers in the pdf.js build process.