### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "license": "MIT",
+  "dependencies": {
+    "argparse": "^2.0.1"
+  }
+}


### PR DESCRIPTION
`argparse` is needed to run the JS build script mentioned in the readme.